### PR TITLE
Fix typo 'Massachussets'

### DIFF
--- a/org.applause.lang.generator.android/sdk/tools/support/typos-en.txt
+++ b/org.applause.lang.generator.android/sdk/tools/support/typos-en.txt
@@ -2671,7 +2671,7 @@ marrage->marriage
 marraige->marriage
 marrtyred->martyred
 marryied->married
-Massachussets->Massachusetts
+Massachusetts->Massachusetts
 Massachussetts->Massachusetts
 massmedia->mass media
 masterbation->masturbation

--- a/org.applause.lang.generator.android/sdk/tools/support/typos-it.txt
+++ b/org.applause.lang.generator.android/sdk/tools/support/typos-it.txt
@@ -519,7 +519,7 @@ maggiorparte->maggior parte
 magolia->magnolia
 managment->management
 marketting->marketing
-Massachussets->Massachusetts
+Massachusetts->Massachusetts
 Massachussetts->Massachusetts
 medacine->medicine
 mercentile->mercantile


### PR DESCRIPTION
Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
should be 'Massachusetts', you typed 'Massachussets'. I created this pull request to fix it!

If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
I’m aware of it.

Looking for the source code of this bot? Well, you have to be patient! The bot is under development
and I will publish the source code as soon as I’m finished with it.

With kind regards,
TheTypoMaster
